### PR TITLE
0.3.10 typing and context

### DIFF
--- a/untp_models/base.py
+++ b/untp_models/base.py
@@ -1,47 +1,71 @@
 from typing import List, Optional
-from pydantic import BaseModel, Field
-from .codes import EvidenceFormat, EncryptionMethod
+from pydantic import BaseModel, Field, AnyUrl
+from .codes import EncryptionMethod, HashMethod
 
 
-class Evidence(BaseModel):
-    format: EvidenceFormat
-    credentialReference: Optional[str] = None
+class IdentifierScheme(BaseModel):
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#identifierscheme
+    type: str = "IdentifierScheme"
+
+    id: AnyUrl  # from vocabulary.uncefact.org/identifierSchemes
+    name: str
 
 
-class Identifier(BaseModel):
-    #https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential#identifier
-    scheme: Optional[str] = None                 # AnyUrl
-    identifierValue: str
-    identifierURI: Optional[str] = None          # AnyUrl
-    verificationEvidence: Optional[Evidence] = None
+class Entity(BaseModel):
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#entity
+    type: str = "Entity"
 
-
-class Party(BaseModel):
-    identifiers: Optional[List[Identifier]] = None
-    name: Optional[str] = None
+    id: AnyUrl
+    name: str
+    registeredId: str
+    idScheme: IdentifierScheme
 
 
 class BinaryFile(BaseModel):
-    fileHash: str
-    fileLocation: str        # AnyUrl
-    fileType: str            # Mimetype
-    encryption_method: EncryptionMethod
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#binaryfile
+    type: str = "BinaryFile"
+
+    fileName: str
+    fileType: str  # https://mimetype.io/all-types
+    file: str  #Base64
 
 
-class Authority(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential#authority
-    number: str
-    authorityEvidence: Evidence
-    trustmark: BinaryFile
-    authority: Party
+class Link(BaseModel):
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#link
+    type: str = "Link"
+
+    linkURL: AnyUrl
+    linkName: str
+    linkType: str  # drawn from a controlled vocabulary
 
 
-class Status(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#status
-    pass
+class SecureLink(BaseModel):
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#securelink
+    type: str = "SecureLink"
+
+    linkUrl: AnyUrl
+    linkName: str
+    linkType: str
+    hashDigest: str
+    hashMethod: HashMethod
+    encryptionMethod: EncryptionMethod
 
 
 class Measure(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#measure
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#measure
+    type: str = "Measure"
+
     value: float
-    unit: str = Field(max_length="3")            # from https://vocabulary.uncefact.org/UnitMeasureCode
+    unit: str = Field(
+        max_length="3")  # from https://vocabulary.uncefact.org/UnitMeasureCode
+
+
+class Endorsement(BaseModel):
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#endorsement
+    type: str = "Endorsement"
+
+    id: str
+    name: str
+    trustmark: BinaryFile
+    issuingAuthority: Entity
+    accreditationCertification: Link

--- a/untp_models/codes.py
+++ b/untp_models/codes.py
@@ -1,19 +1,18 @@
 from enum import Enum
-from pydantic import BaseModel, AnyUrl
 
 
-class AssessorAssuranceCode(str, Enum):
-    #https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#assessorassurancecode
+class AssessorLevelCode(str, Enum):
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#assessorLevelCode
     Self = "Self"
     Commercial = "Commercial"
     Buyer = "Buyer"
     Membership = "Membership"
     Unspecified = "Unspecified"
-    ThirdParty = "ThirdParty"
+    ThirdParty = "3rdParty"
 
 
-class AssessmentAssuranceCode(str, Enum):
-    #https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#assessmentassurancecode
+class AssessmentLevelCode(str, Enum):
+    #https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#assessmentlevelcode
     GovtApproval = "GovtApproval"
     GlobalMLA = "GlobalMLA"
     Accredited = "Accredited"
@@ -33,22 +32,19 @@ class AttestationType(str, Enum):
     Calibration = "Calibration"
 
 
+class HashMethod(str, Enum):
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#hashmethodcode
+    SHA256 = "SHA-256"
+    SHA1 = "SHA-1"
+
+
 class EncryptionMethod(str, Enum):
     NONE = "None"
     AES = "AES"
 
 
-class EvidenceFormat(str, Enum):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#evidenceformat
-    W3C_VC = "W3C_VC"
-    ISO_MDL = "ISO_MDL"
-    Document = "Document"
-    Website = "Website"
-    Other = "Other"
-
-
-class SustainabilityTopic(str, Enum):
-    #https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#sustainabilitytopic
+class ConformityTopicCode(str, Enum):
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#conformityTopicCode
     Environment_Energy = "Environment.Energy"
     Environment_Emissions = "Environment.Emissions"
     Environment_Water = "Environment.Water"
@@ -60,6 +56,7 @@ class SustainabilityTopic(str, Enum):
     Social_Labour = "Social.Labour"
     Social_Rights = "Social.Rights"
     Social_Safety = "Social.Safety"
+    Social_Community = "Social.Community"
     Governance_Ethics = "Governance.Ethics"
     Governance_Compliance = "Governance.Compliance"
     Governance_Transparency = "Governance.Transparency"

--- a/untp_models/conformity_credential.py
+++ b/untp_models/conformity_credential.py
@@ -1,120 +1,108 @@
 from typing import List, Optional
-from pydantic import BaseModel
-from .codes import AssessorAssuranceCode, AssessmentAssuranceCode, AttestationType, SustainabilityTopic
-from .base import Party, Authority, Status, Identifier, Measure, BinaryFile
-
-
-class Classification(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#classification
-    scheme: str                                  # str #AnyUrl
-    classifierValue: Optional[str] = None
-    classifierName: str
-    classifierURL: Optional[str] = None          # str #AnyUrl
+from pydantic import BaseModel, AnyUrl
+from .codes import AssessorLevelCode, AssessmentLevelCode, AttestationType, ConformityTopicCode
+from .base import Entity, Measure, BinaryFile, SecureLink, Endorsement, IdentifierScheme
 
 
 class Standard(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#standard
-    id: str                  # str #AnyUrl
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#standard
     type: str = "Standard"
+
+    id: AnyUrl
     name: str
-    issuingBody: Party
-    issueDate: str           #iso8601 datetime string
+    issuingParty: Entity
+    issueDate: str  #iso8601 datetime string
 
 
 class Regulation(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#regulation
-    id: str                  # str #AnyUrl
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#regulation
     type: str = "Regulation"
+
+    id: AnyUrl
     name: str
-    issuingBody: Party
-    effectiveDate: str       #iso8601 datetime string
+    jurisdictionCountry: str  #countryCode from https://vocabulary.uncefact.org/CountryId
+    administeredBy: Entity
+    effectiveDate: str  #iso8601 datetime string
 
 
 class Metric(BaseModel):
-    name: str
-    value: Measure
-    minimumValue: Measure
-    maximumValue: Measure
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#metric
+    type: str = "Metric"
+
+    metricName: str
+    metricValue: Measure
+    accuracy: float
 
 
 class Criterion(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#criteria
-    id: str   # str #AnyUrl
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#criterion
     type: str = "Criterion"
-    threshold: Metric
+
+    id: AnyUrl
     name: str
+    thresholdValues: Metric
 
 
 class Facility(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#product
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#facility
     type: str = "Facility"
-    identifiers: Optional[List[Identifier]] = None
+
+    # this looks wrongs
     name: str
-    classifications: Optional[List[Classification]] = None
-    geolocation: str         # str #AnyUrl for https://plus.codes/4RQGGVGP+ can be converted https://www.dcode.fr/open-location-code
-    verifiedByCAB: bool
+    registeredId: str
+    idScheme: IdentifierScheme
+    IDverifiedByCAB: bool
 
 
 class Product(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#product
-    type:str = "Product"
-    identifiers: Optional[List[Identifier]] = None
-    marking: Optional[str] = None
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#product
+    type: str = "Product"
+
+    id: AnyUrl  # The globally unique ID of the entity as a resolvable URL according to ISO 18975.
     name: str
-    classifications: Optional[Classification] = None
-    testedBatchId: Optional[str] = None          # str #AnyUrl
-    verifiedByCAB: bool
+    registeredId: str
+    idScheme: IdentifierScheme
+    IDverifiedByCAB: bool
 
 
 class ConformityAssessment(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#conformityassessment
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#conformityassessment
     type: str = "ConformityAssessment"
-    referenceStandard: Optional[Standard] = None     #defines the specification
-    referenceRegulation: Optional[Regulation] = None #defines the regulation
+
+    id: str
+    referenceStandard: Optional[Standard] = None  #defines the specification
+    referenceRegulation: Optional[Regulation] = None  #defines the regulation
     assessmentCriterion: Optional[Criterion] = None  #defines the criteria
-    subjectProducts: Optional[List[Product]] = None
-    subjectFacilities: List[Facility]
-    measuredResults: Optional[List[Metric]] = None
+    declaredValues: Optional[List[Metric]] = None
     complaince: Optional[bool] = False
-    sustainabilityTopic: SustainabilityTopic
+    conformityTopic: ConformityTopicCode
+
+    assessedProducts: Optional[List[Product]] = None
+    assessedFacilities: Optional[List[Facility]] = None
 
 
 class ConformityAssessmentScheme(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#conformityattestation
-    id: str 
-    type:str = "ConformityAssessmentScheme"                                     # str #AnyUrl
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#conformityassessmentscheme
+    type: str = "ConformityAssessmentScheme"
+
+    id: str
     name: str
+    issuingParty: Optional[Entity] = None
+    issueDate: Optional[str] = None  #ISO8601 datetime string
     trustmark: Optional[BinaryFile] = None
-    issuingBody: Optional[Party] = None
-    dateOfIssue: Optional[str] = None            #ISO8601 datetime string
-
-
-class ConformityEvidence(BaseModel):
-    evidenceRootHash: str                        #md5 hash
-    description: str
-    evidenceFiles: List[BinaryFile]
-    decryptionKeyRequest: str                    # str #AnyUrl
 
 
 class ConformityAttestation(BaseModel):
-    # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#conformityattestation
-    id: str 
-    type: str = "ConformityAttestation"                                     #AnyUrl
-    assessorLevel: Optional[AssessorAssuranceCode] = None
-    assessmentLevel: AssessmentAssuranceCode
-    type: AttestationType
-    description: str
+    # https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render#ConformityAttestation
+    type: str = "ConformityAttestation"
+    id: str
+    assessorLevel: Optional[AssessorLevelCode] = None
+    assessmentLevel: AssessmentLevelCode
+    attestationType: AttestationType
+    attestationDescription: str
+    issuedToParty: Entity
+    authorisations: Endorsement
+    conformityCertificate: SecureLink
+    auditableEvidence: SecureLink
     scope: ConformityAssessmentScheme
-    issuedBy: Party
-    issuedTo: Party
-    validFrom: str                               #iso8601 datetime string
-    validTo: Optional[str] = None                #iso8601 datetime string
-    status: Optional[Status] = None
-    assessments: List[
-        ConformityAssessment]                    #list of assessments that are part of this attestation, that this is a real mine.
-    evidence: Optional[
-        List[ConformityEvidence]] = None         #multi-media proof of claim (pictures, videos, etc)
-    accreditation: Optional[Authority] = None    #proof that CPO is the right authority (from BC Gov)
-    regulatoryApproval: Optional[
-        Authority] = None                        #regulation that allows CPO to issue this credential
-    certificate: Optional[BinaryFile] = None     #a human readable document, e.g. PDF
+    assessments: List[ConformityAssessment]

--- a/untp_models/conformity_credential.py
+++ b/untp_models/conformity_credential.py
@@ -15,6 +15,7 @@ class Classification(BaseModel):
 class Standard(BaseModel):
     # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#standard
     id: str                  # str #AnyUrl
+    type: str = "Standard"
     name: str
     issuingBody: Party
     issueDate: str           #iso8601 datetime string
@@ -23,6 +24,7 @@ class Standard(BaseModel):
 class Regulation(BaseModel):
     # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#regulation
     id: str                  # str #AnyUrl
+    type: str = "Regulation"
     name: str
     issuingBody: Party
     effectiveDate: str       #iso8601 datetime string
@@ -38,12 +40,14 @@ class Metric(BaseModel):
 class Criterion(BaseModel):
     # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#criteria
     id: str   # str #AnyUrl
+    type: str = "Criterion"
     threshold: Metric
     name: str
 
 
 class Facility(BaseModel):
     # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#product
+    type: str = "Facility"
     identifiers: Optional[List[Identifier]] = None
     name: str
     classifications: Optional[List[Classification]] = None
@@ -53,6 +57,7 @@ class Facility(BaseModel):
 
 class Product(BaseModel):
     # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#product
+    type:str = "Product"
     identifiers: Optional[List[Identifier]] = None
     marking: Optional[str] = None
     name: str
@@ -63,6 +68,7 @@ class Product(BaseModel):
 
 class ConformityAssessment(BaseModel):
     # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#conformityassessment
+    type: str = "ConformityAssessment"
     referenceStandard: Optional[Standard] = None     #defines the specification
     referenceRegulation: Optional[Regulation] = None #defines the regulation
     assessmentCriterion: Optional[Criterion] = None  #defines the criteria
@@ -75,7 +81,8 @@ class ConformityAssessment(BaseModel):
 
 class ConformityAssessmentScheme(BaseModel):
     # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#conformityattestation
-    id: str                                      # str #AnyUrl
+    id: str 
+    type:str = "ConformityAssessmentScheme"                                     # str #AnyUrl
     name: str
     trustmark: Optional[BinaryFile] = None
     issuingBody: Optional[Party] = None
@@ -91,7 +98,8 @@ class ConformityEvidence(BaseModel):
 
 class ConformityAttestation(BaseModel):
     # https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#conformityattestation
-    id: str                                      #AnyUrl
+    id: str 
+    type: str = "ConformityAttestation"                                     #AnyUrl
     assessorLevel: Optional[AssessorAssuranceCode] = None
     assessmentLevel: AssessmentAssuranceCode
     type: AttestationType


### PR DESCRIPTION
Update models to match version 3.10. 

UNTP link: https://uncefact.github.io/spec-untp/docs/specification/ConformityCredential/#conformityattestation
Jargon Link:  https://jargon.sh/user/unece/ConformityCredential/v/0.3.10/artefacts/readme/render
